### PR TITLE
Avoid global install of browserify using npx

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 mkdir -p build
-browserify index.js -p [ tsify ] > build/index_bundle.js
+npx browserify index.js -p [ tsify ] > build/index_bundle.js


### PR DESCRIPTION
Running the sample found you need `browserify` installed globally.
This change uses `npx` to call **browserify** on the fly only for this project.